### PR TITLE
Add transaction count to statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If not set, `from` defaults to UNIX timestamp `0`, `to` to `now`.
       "asset_code": "CNDY",
       "asset_issuer": "GCJKC2MI63KSQ6MLE6GBSXPDKTDAK43WR522ZYR3F34NPM7Z5UEPIZNX",
       "num_accounts": 10,
-      "num_effects": 58,
+      "payments": 25,
       "created_at": "2018-03-24T08:24:06Z",
       "total_amount": "4000.0000000"
     },
@@ -151,7 +151,7 @@ If not set, `from` defaults to UNIX timestamp `0`, `to` to `now`.
       "asset_code": "CNDY",
       "asset_issuer": "GCJKC2MI63KSQ6MLE6GBSXPDKTDAK43WR522ZYR3F34NPM7Z5UEPIZNX",
       "num_accounts": 10,
-      "num_effects": 59,
+      "payments": 28,
       "created_at": "2018-03-24T08:24:06Z",
       "total_amount": "4000.0000000"
     }

--- a/controllers/docs/docs.go
+++ b/controllers/docs/docs.go
@@ -91,7 +91,7 @@ const htmlData = `
 	<a class="sourceLine" id="cb3-6" data-line-number="6">      <span class="dt">&quot;asset_code&quot;</span><span class="fu">:</span> <span class="st">&quot;CNDY&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-7" data-line-number="7">      <span class="dt">&quot;asset_issuer&quot;</span><span class="fu">:</span> <span class="st">&quot;GCJKC2MI63KSQ6MLE6GBSXPDKTDAK43WR522ZYR3F34NPM7Z5UEPIZNX&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-8" data-line-number="8">      <span class="dt">&quot;num_accounts&quot;</span><span class="fu">:</span> <span class="dv">10</span><span class="fu">,</span></a>
-	<a class="sourceLine" id="cb3-9" data-line-number="9">      <span class="dt">&quot;num_effects&quot;</span><span class="fu">:</span> <span class="dv">58</span><span class="fu">,</span></a>
+	<a class="sourceLine" id="cb3-9" data-line-number="9">      <span class="dt">&quot;payments&quot;</span><span class="fu">:</span> <span class="dv">58</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-10" data-line-number="10">      <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-24T08:24:06Z&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-11" data-line-number="11">      <span class="dt">&quot;total_amount&quot;</span><span class="fu">:</span> <span class="st">&quot;4000.0000000&quot;</span></a>
 	<a class="sourceLine" id="cb3-12" data-line-number="12">    <span class="fu">}</span><span class="ot">,</span></a>
@@ -101,7 +101,7 @@ const htmlData = `
 	<a class="sourceLine" id="cb3-16" data-line-number="16">      <span class="dt">&quot;asset_code&quot;</span><span class="fu">:</span> <span class="st">&quot;CNDY&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-17" data-line-number="17">      <span class="dt">&quot;asset_issuer&quot;</span><span class="fu">:</span> <span class="st">&quot;GCJKC2MI63KSQ6MLE6GBSXPDKTDAK43WR522ZYR3F34NPM7Z5UEPIZNX&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-18" data-line-number="18">      <span class="dt">&quot;num_accounts&quot;</span><span class="fu">:</span> <span class="dv">10</span><span class="fu">,</span></a>
-	<a class="sourceLine" id="cb3-19" data-line-number="19">      <span class="dt">&quot;num_effects&quot;</span><span class="fu">:</span> <span class="dv">59</span><span class="fu">,</span></a>
+	<a class="sourceLine" id="cb3-19" data-line-number="19">      <span class="dt">&quot;payments&quot;</span><span class="fu">:</span> <span class="dv">59</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-20" data-line-number="20">      <span class="dt">&quot;created_at&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-24T08:24:06Z&quot;</span><span class="fu">,</span></a>
 	<a class="sourceLine" id="cb3-21" data-line-number="21">      <span class="dt">&quot;total_amount&quot;</span><span class="fu">:</span> <span class="st">&quot;4000.0000000&quot;</span></a>
 	<a class="sourceLine" id="cb3-22" data-line-number="22">    <span class="fu">}</span></a>

--- a/controllers/history/history_test.go
+++ b/controllers/history/history_test.go
@@ -112,7 +112,7 @@ func TestHistory(t *testing.T) {
 			s = append(s, fmt.Sprintf(`"paging_token":"%s"`, e.PagingToken))
 			s = append(s, fmt.Sprintf(`"total_amount":"%s"`, bigint.ToString(e.TotalAmount)))
 			s = append(s, fmt.Sprintf(`"num_accounts":%d`, e.NumAccounts))
-			s = append(s, fmt.Sprintf(`"num_effects":%d`, e.NumEffects))
+			s = append(s, fmt.Sprintf(`"payments":%d`, e.Payments))
 
 			for _, contains := range s {
 				if !strings.Contains(resp.Body.String(), contains) {

--- a/controllers/stats/stats.go
+++ b/controllers/stats/stats.go
@@ -26,7 +26,7 @@ func Init(db interface{}, router *gin.Engine) {
 
 		c.JSON(http.StatusOK, gin.H{
 			"asset_code":         cndy.AssetCode,
-			"effect_count":       effect.ItemCount(db, effect.Filter{From: from, To: to}),
+			"payments":           effect.TotalCount(db, effect.Filter{Type: "account_debited", From: from, To: to}),
 			"accounts_involved":  effect.AccountCount(db, effect.Filter{From: from, To: to}),
 			"amount_transferred": bigint.ToString(effect.TotalAmount(db, effect.Filter{Type: "account_credited", From: from, To: to})),
 			"trustlines_created": effect.TotalCount(db, effect.Filter{Type: "trustline_created", From: from, To: to}),

--- a/controllers/stats/stats_test.go
+++ b/controllers/stats/stats_test.go
@@ -46,7 +46,7 @@ func TestStats(t *testing.T) {
 			http.StatusOK,
 			[]string{
 				fmt.Sprintf(`"asset_code":"%s"`, cndy.AssetCode),
-				`"effect_count":8`,
+				`"payments":3`,
 				`"accounts_involved":3`,
 				`"amount_issued":"1100.0000000"`,
 				`"trustlines_created":2`,
@@ -63,7 +63,7 @@ func TestStats(t *testing.T) {
 			http.StatusOK,
 			[]string{
 				fmt.Sprintf(`"asset_code":"%s"`, cndy.AssetCode),
-				`"effect_count":4`,
+				`"payments":2`,
 				`"accounts_involved":3`,
 				`"amount_issued":"100.0000000"`,
 				`"trustlines_created":0`,
@@ -80,7 +80,7 @@ func TestStats(t *testing.T) {
 			http.StatusOK,
 			[]string{
 				fmt.Sprintf(`"asset_code":"%s"`, cndy.AssetCode),
-				`"effect_count":5`,
+				`"payments":1`,
 				`"accounts_involved":3`,
 				`"amount_issued":"1000.0000000"`,
 				`"trustlines_created":2`,
@@ -97,7 +97,7 @@ func TestStats(t *testing.T) {
 			http.StatusOK,
 			[]string{
 				fmt.Sprintf(`"asset_code":"%s"`, cndy.AssetCode),
-				`"effect_count":3`,
+				`"payments":1`,
 				`"accounts_involved":3`,
 				`"amount_issued":"1000.0000000"`,
 				`"trustlines_created":1`,

--- a/db/migrations/0004_add_payments_to_asset_stats.down.sql
+++ b/db/migrations/0004_add_payments_to_asset_stats.down.sql
@@ -1,0 +1,28 @@
+ALTER TABLE asset_stats DROP COLUMN payments;
+ALTER TABLE asset_stats ADD COLUMN num_effects integer;
+
+CREATE OR REPLACE FUNCTION repopulate_asset_stats()
+  RETURNS VOID
+AS
+$$
+DECLARE
+   t_row effects%rowtype;
+BEGIN
+    TRUNCATE asset_stats;
+    FOR t_row in SELECT * FROM effects LOOP
+      INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, num_effects)
+          VALUES (t_row.paging_token, t_row.asset_code, t_row.asset_issuer, t_row.asset_type, t_row.created_at,
+              (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
+              (SELECT COUNT(DISTINCT account) FROM effects WHERE effect_id <= t_row.effect_id),
+              (SELECT COUNT(*) FROM effects WHERE type='account_debited' AND effect_id <= t_row.effect_id),
+              (SELECT COUNT(*) FROM effects WHERE effect_id <= t_row.effect_id)
+          );
+    END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Re-populate asset_stats table
+SELECT repopulate_asset_stats();
+
+DROP FUNCTION repopulate_asset_stats;

--- a/db/migrations/0004_add_payments_to_asset_stats.down.sql
+++ b/db/migrations/0004_add_payments_to_asset_stats.down.sql
@@ -12,7 +12,7 @@ BEGIN
     FOR t_row in SELECT * FROM effects LOOP
       INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, num_effects)
           VALUES (t_row.paging_token, t_row.asset_code, t_row.asset_issuer, t_row.asset_type, t_row.created_at,
-              (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
+              (SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
               (SELECT COUNT(DISTINCT account) FROM effects WHERE effect_id <= t_row.effect_id),
               (SELECT COUNT(*) FROM effects WHERE type='account_debited' AND effect_id <= t_row.effect_id),
               (SELECT COUNT(*) FROM effects WHERE effect_id <= t_row.effect_id)

--- a/db/migrations/0004_add_payments_to_asset_stats.up.sql
+++ b/db/migrations/0004_add_payments_to_asset_stats.up.sql
@@ -1,0 +1,25 @@
+ALTER TABLE asset_stats DROP COLUMN num_effects;
+ALTER TABLE asset_stats ADD COLUMN payments integer;
+
+CREATE FUNCTION repopulate_asset_stats()
+  RETURNS VOID
+AS
+$$
+DECLARE
+   t_row effects%rowtype;
+BEGIN
+    TRUNCATE asset_stats;
+    FOR t_row in SELECT * FROM effects LOOP
+      INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, payments)
+          VALUES (t_row.paging_token, t_row.asset_code, t_row.asset_issuer, t_row.asset_type, t_row.created_at,
+              (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
+              (SELECT COUNT(DISTINCT account) FROM effects WHERE effect_id <= t_row.effect_id),
+              (SELECT COUNT(*) FROM effects WHERE type='account_debited' AND effect_id <= t_row.effect_id)
+          );
+    END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Re-populate asset_stats table
+SELECT repopulate_asset_stats();

--- a/db/migrations/0004_add_payments_to_asset_stats.up.sql
+++ b/db/migrations/0004_add_payments_to_asset_stats.up.sql
@@ -12,7 +12,7 @@ BEGIN
     FOR t_row in SELECT * FROM effects LOOP
       INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, payments)
           VALUES (t_row.paging_token, t_row.asset_code, t_row.asset_issuer, t_row.asset_type, t_row.created_at,
-              (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
+              (SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account=t_row.asset_issuer AND created_at <= t_row.created_at),
               (SELECT COUNT(DISTINCT account) FROM effects WHERE effect_id <= t_row.effect_id),
               (SELECT COUNT(*) FROM effects WHERE type='account_debited' AND effect_id <= t_row.effect_id)
           );

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -27,7 +27,7 @@ func New(db interface{}, effect horizon.Effect, timestamp time.Time) (err error)
 	// (analogue to the asset endpoint of Horizon)
 	_, err = sql.Exec(db, `INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, payments)
 		                   VALUES ($1, $2, $3, $4, $5,
-		                       (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=$6),
+		                       (SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account=$6),
 		                       (SELECT COUNT(DISTINCT account) FROM effects),
 		                       (SELECT COUNT(*) FROM effects WHERE type='account_debited')
 		                   )`,

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -15,7 +15,7 @@ type AssetStat struct {
 	AssetIssuer *string    `db:"asset_issuer" json:"asset_issuer,omitempty"`
 	TotalAmount *int64     `db:"total_amount" json:"-"`
 	NumAccounts *int32     `db:"num_accounts" json:"num_accounts,omitempty"`
-	NumEffects  *int32     `db:"num_effects"  json:"num_effects,omitempty"`
+	Payments    *int32     `db:"payments"  json:"payments,omitempty"`
 	CreatedAt   *time.Time `db:"created_at"   json:"created_at,omitempty"`
 
 	// These fields are used by .Convert()
@@ -25,12 +25,12 @@ type AssetStat struct {
 func New(db interface{}, effect horizon.Effect, timestamp time.Time) (err error) {
 	// Store amount_transfered and amount_issued upon insert in a different table
 	// (analogue to the asset endpoint of Horizon)
-	_, err = sql.Exec(db, `INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, num_effects)
+	_, err = sql.Exec(db, `INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, total_amount, num_accounts, payments)
 		                   VALUES ($1, $2, $3, $4, $5,
-						       (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=$6),
+		                       (SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=$6),
 		                       (SELECT COUNT(DISTINCT account) FROM effects),
-		                       (SELECT COUNT(*) FROM effects)
-						   )`,
+		                       (SELECT COUNT(*) FROM effects WHERE type='account_debited')
+		                   )`,
 		effect.PT, effect.Asset.Code, effect.Asset.Issuer, effect.Asset.Type, timestamp, effect.Asset.Issuer)
 
 	return

--- a/models/effect/effect.go
+++ b/models/effect/effect.go
@@ -149,7 +149,7 @@ func TotalAmount(db interface{}, filter Filter) (amount int64) {
 		return
 	}
 
-	err := sql.Get(db, &amount, `SELECT SUM(amount) FROM effects WHERE type=$1 AND created_at BETWEEN $2::timestamp AND $3::timestamp`,
+	err := sql.Get(db, &amount, `SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type=$1 AND created_at BETWEEN $2::timestamp AND $3::timestamp`,
 		filter.Type, filter.From, filter.To)
 	if err != nil {
 		log.Print(err)
@@ -163,7 +163,7 @@ func TotalAmount(db interface{}, filter Filter) (amount int64) {
 func TotalIssued(db interface{}, issuer string, filter Filter) (issued int64) {
 	filter.Defaults()
 
-	err := sql.Get(db, &issued, `SELECT SUM(amount) FROM effects WHERE type='account_debited' AND account=$1 AND created_at BETWEEN $2::timestamp AND $3::timestamp`,
+	err := sql.Get(db, &issued, `SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account=$1 AND created_at BETWEEN $2::timestamp AND $3::timestamp`,
 		issuer, filter.From, filter.To)
 	if err != nil {
 		log.Print(err)

--- a/models/effect/effect_test.go
+++ b/models/effect/effect_test.go
@@ -158,8 +158,8 @@ func TestNew(t *testing.T) {
 	if *a.NumAccounts != 1 {
 		t.Errorf("Expected 1 got %v", *a.NumAccounts)
 	}
-	if *a.NumEffects != 1 {
-		t.Errorf("Expected 1 got %v", *a.NumEffects)
+	if *a.Payments != 1 {
+		t.Errorf("Expected 1 got %v", *a.Payments)
 	}
 	if *e.CreatedAt != *a.CreatedAt {
 		t.Errorf("Expected %v got %v", e.CreatedAt, *a.CreatedAt)

--- a/utils/test/test.go
+++ b/utils/test/test.go
@@ -32,15 +32,15 @@ type AssetStat struct {
 	PagingToken string
 	TotalAmount int64
 	NumAccounts int32
-	NumEffects  int32
+	Payments    int32
 	CreatedAt   time.Time
 }
 
 var AssetStats = []AssetStat{
-	{"39819440072110101-0", 10000000000, 10, 50, time.Date(2018, time.March, 12, 0, 0, 0, 0, time.UTC)},
-	{"39819440072110101-1", 10000000000, 12, 60, time.Date(2018, time.March, 14, 0, 0, 0, 0, time.UTC)},
-	{"39819440072110101-2", 20000000000, 15, 70, time.Date(2018, time.March, 16, 0, 0, 0, 0, time.UTC)},
-	{"39819440072110101-3", 20000000000, 22, 80, time.Date(2018, time.March, 18, 0, 0, 0, 0, time.UTC)},
+	{"39819440072110101-0", 10000000000, 10, 20, time.Date(2018, time.March, 12, 0, 0, 0, 0, time.UTC)},
+	{"39819440072110101-1", 10000000000, 12, 25, time.Date(2018, time.March, 14, 0, 0, 0, 0, time.UTC)},
+	{"39819440072110101-2", 20000000000, 15, 30, time.Date(2018, time.March, 16, 0, 0, 0, 0, time.UTC)},
+	{"39819440072110101-3", 20000000000, 22, 35, time.Date(2018, time.March, 18, 0, 0, 0, 0, time.UTC)},
 }
 
 // Helper function to insert test data
@@ -65,9 +65,9 @@ func InsertEffects(tx *sqlx.Tx) (err error) {
 
 func InsertAssetStats(tx *sqlx.Tx) (err error) {
 	for _, data := range AssetStats {
-		_, err = tx.Exec(`INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, total_amount, num_accounts, num_effects, created_at)
+		_, err = tx.Exec(`INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, total_amount, num_accounts, payments, created_at)
 			              VALUES($1, $2, $3, 'credit_alphanum4', $4, $5, $6, $7)`,
-			data.PagingToken, cndy.AssetCode, cndy.AssetIssuer, data.TotalAmount, data.NumAccounts, data.NumEffects, data.CreatedAt)
+			data.PagingToken, cndy.AssetCode, cndy.AssetIssuer, data.TotalAmount, data.NumAccounts, data.Payments, data.CreatedAt)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This adds another statistic to the `asset_stats` model (and the respective `history` controller).
I think that the transaction count is a better metric than effects and should be replaced in the frontend eventually.