### PR TITLE
Use custom interface for database instead of generic one

### DIFF
--- a/controllers/effects/effects.go
+++ b/controllers/effects/effects.go
@@ -3,12 +3,13 @@ package effects
 import (
 	"github.com/cndy-store/analytics/models/effect"
 	"github.com/cndy-store/analytics/utils/filter"
+	"github.com/cndy-store/analytics/utils/sql"
 	"github.com/gin-gonic/gin"
 	"log"
 	"net/http"
 )
 
-func Init(db interface{}, router *gin.Engine) {
+func Init(db sql.Database, router *gin.Engine) {
 	// GET /effects[?from=XXX&to=XXX]
 	router.GET("/effects", func(c *gin.Context) {
 		from, to, err := filter.Parse(c)

--- a/controllers/stats/stats.go
+++ b/controllers/stats/stats.go
@@ -4,12 +4,13 @@ import (
 	"github.com/cndy-store/analytics/models/asset_stat"
 	"github.com/cndy-store/analytics/models/cursor"
 	"github.com/cndy-store/analytics/utils/filter"
+	"github.com/cndy-store/analytics/utils/sql"
 	"github.com/gin-gonic/gin"
 	"log"
 	"net/http"
 )
 
-func Init(db interface{}, router *gin.Engine) {
+func Init(db sql.Database, router *gin.Engine) {
 	// GET /stats[?from=XXX&to=XXX]
 	router.GET("/stats", func(c *gin.Context) {
 		from, to, err := filter.Parse(c)

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -80,7 +80,7 @@ func Get(db sql.Database, filter Filter) (stats []AssetStat, err error) {
 }
 
 func Latest(db sql.Database) (stats AssetStat, err error) {
-	err = sql.Get(db, &stats, `SELECT * FROM asset_stats ORDER BY id DESC LIMIT 1`)
+	err = db.Get(&stats, `SELECT * FROM asset_stats ORDER BY id DESC LIMIT 1`)
 	if err == sql.ErrNoRows {
 		log.Printf("[ERROR] asset_stat.Latest(): %s", err)
 	}

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -29,7 +29,7 @@ type AssetStat struct {
 	JsonTransferred *string `db:"-" json:"transferred"`
 }
 
-func New(db interface{}, effect horizon.Effect, timestamp time.Time) (err error) {
+func New(db sql.Database, effect horizon.Effect, timestamp time.Time) (err error) {
 	// Store amount_transfered and amount_issued upon insert in a different table
 	// (analogue to the asset endpoint of Horizon)
 
@@ -63,7 +63,7 @@ func (f *Filter) Defaults() {
 	}
 }
 
-func Get(db interface{}, filter Filter) (stats []AssetStat, err error) {
+func Get(db sql.Database, filter Filter) (stats []AssetStat, err error) {
 	filter.Defaults()
 	err = sql.Select(db, &stats, `SELECT * FROM asset_stats WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY id`,
 		filter.From, filter.To)
@@ -79,7 +79,7 @@ func Get(db interface{}, filter Filter) (stats []AssetStat, err error) {
 	return
 }
 
-func Latest(db interface{}) (stats AssetStat, err error) {
+func Latest(db sql.Database) (stats AssetStat, err error) {
 	err = sql.Get(db, &stats, `SELECT * FROM asset_stats ORDER BY id DESC LIMIT 1`)
 	if err == sql.ErrNoRows {
 		log.Printf("[ERROR] asset_stat.Latest(): %s", err)

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -33,7 +33,7 @@ func New(db sql.Database, effect horizon.Effect, timestamp time.Time) (err error
 	// Store amount_transfered and amount_issued upon insert in a different table
 	// (analogue to the asset endpoint of Horizon)
 
-	_, err = sql.Exec(db, `INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, issued, transferred, accounts_with_trustline, accounts_with_payments, payments)
+	_, err = db.Exec(`INSERT INTO asset_stats(paging_token, asset_code, asset_issuer, asset_type, created_at, issued, transferred, accounts_with_trustline, accounts_with_payments, payments)
 		                   VALUES ($1, $2, $3, $4, $5,
 		                       (SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account=$6),
 		                       (SELECT COALESCE(SUM(amount), 0) FROM effects WHERE type='account_debited' AND account!=$6),

--- a/models/asset_stat/asset_stat.go
+++ b/models/asset_stat/asset_stat.go
@@ -65,7 +65,7 @@ func (f *Filter) Defaults() {
 
 func Get(db sql.Database, filter Filter) (stats []AssetStat, err error) {
 	filter.Defaults()
-	err = sql.Select(db, &stats, `SELECT * FROM asset_stats WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY id`,
+	err = db.Select(&stats, `SELECT * FROM asset_stats WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY id`,
 		filter.From, filter.To)
 	if err == sql.ErrNoRows {
 		log.Printf("[ERROR] asset_stat.Get(): %s", err)

--- a/models/cursor/cursor.go
+++ b/models/cursor/cursor.go
@@ -18,12 +18,12 @@ func Update(cursor horizon.Cursor) {
 	Current = cursor
 }
 
-func Save(db interface{}) (err error) {
+func Save(db sql.Database) (err error) {
 	_, err = sql.Exec(db, `UPDATE cursors SET paging_token=$1 WHERE id=1`, Current)
 	return
 }
 
-func LoadLatest(db interface{}) (err error) {
+func LoadLatest(db sql.Database) (err error) {
 	var c string
 	err = sql.Get(db, &c, `SELECT paging_token FROM cursors WHERE id=1`)
 	if err != nil {

--- a/models/cursor/cursor.go
+++ b/models/cursor/cursor.go
@@ -19,7 +19,7 @@ func Update(cursor horizon.Cursor) {
 }
 
 func Save(db sql.Database) (err error) {
-	_, err = sql.Exec(db, `UPDATE cursors SET paging_token=$1 WHERE id=1`, Current)
+	_, err = db.Exec(`UPDATE cursors SET paging_token=$1 WHERE id=1`, Current)
 	return
 }
 

--- a/models/cursor/cursor.go
+++ b/models/cursor/cursor.go
@@ -25,7 +25,7 @@ func Save(db sql.Database) (err error) {
 
 func LoadLatest(db sql.Database) (err error) {
 	var c string
-	err = sql.Get(db, &c, `SELECT paging_token FROM cursors WHERE id=1`)
+	err = db.Get(&c, `SELECT paging_token FROM cursors WHERE id=1`)
 	if err != nil {
 		return
 	}

--- a/models/effect/effect.go
+++ b/models/effect/effect.go
@@ -80,7 +80,7 @@ func New(db sql.Database, effect horizon.Effect) (err error) {
 	}
 
 	// Just input the fields we're requiring for now, can be replayed anytime form the chain later.
-	_, err = sql.Exec(db, `INSERT INTO effects(
+	_, err = db.Exec(`INSERT INTO effects(
 			effect_id,
 			operation, succeeds, precedes,
 			paging_token, account, amount, type, type_i, starting_balance,

--- a/models/effect/effect.go
+++ b/models/effect/effect.go
@@ -144,7 +144,7 @@ func (f *Filter) Defaults() {
 
 func Get(db sql.Database, filter Filter) (effects []Effect, err error) {
 	filter.Defaults()
-	err = sql.Select(db, &effects, `SELECT * FROM effects WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY created_at`,
+	err = db.Select(&effects, `SELECT * FROM effects WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY created_at`,
 		filter.From, filter.To)
 	if err == sql.ErrNoRows {
 		log.Printf("[ERROR] effect.Get(): %s", err)

--- a/models/effect/effect.go
+++ b/models/effect/effect.go
@@ -49,7 +49,7 @@ type Operation struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-func New(db interface{}, effect horizon.Effect) (err error) {
+func New(db sql.Database, effect horizon.Effect) (err error) {
 	// Get operation
 	operation := getOperation(effect.Links.Operation.Href)
 
@@ -142,7 +142,7 @@ func (f *Filter) Defaults() {
 	}
 }
 
-func Get(db interface{}, filter Filter) (effects []Effect, err error) {
+func Get(db sql.Database, filter Filter) (effects []Effect, err error) {
 	filter.Defaults()
 	err = sql.Select(db, &effects, `SELECT * FROM effects WHERE created_at BETWEEN $1::timestamp AND $2::timestamp ORDER BY created_at`,
 		filter.From, filter.To)

--- a/utils/sql/sql.go
+++ b/utils/sql/sql.go
@@ -51,11 +51,6 @@ func OpenAndMigrate(relPath string) (db *sqlx.DB, err error) {
 	return
 }
 
-// Select is a type agnostic wrapper for sqlx.Select() (works with sqlx.DB and sqlx.Tx)
-func Select(db Database, obj interface{}, query string, args ...interface{}) (err error) {
-	return db.Select(obj, query, args...)
-}
-
 // NamedQuery is a type agnostic wrapper for sqlx.NamedQuery() (works with sqlx.DB and sqlx.Tx)
 func NamedQuery(db Database, obj interface{}, query string, arg interface{}) (err error) {
 	var stmt *sqlx.NamedStmt

--- a/utils/sql/sql.go
+++ b/utils/sql/sql.go
@@ -51,11 +51,6 @@ func OpenAndMigrate(relPath string) (db *sqlx.DB, err error) {
 	return
 }
 
-// Getis a type agnostic wrapper for sqlx.Get() (works with sqlx.DB and sqlx.Tx)
-func Get(db Database, obj interface{}, query string, args ...interface{}) (err error) {
-	return db.Get(obj, query, args...)
-}
-
 // Select is a type agnostic wrapper for sqlx.Select() (works with sqlx.DB and sqlx.Tx)
 func Select(db Database, obj interface{}, query string, args ...interface{}) (err error) {
 	return db.Select(obj, query, args...)

--- a/utils/sql/sql.go
+++ b/utils/sql/sql.go
@@ -51,11 +51,6 @@ func OpenAndMigrate(relPath string) (db *sqlx.DB, err error) {
 	return
 }
 
-// Exec is a type agnostic wrapper for sqlx.Exec() (works with sqlx.DB and sqlx.Tx)
-func Exec(db Database, query string, args ...interface{}) (result sql.Result, err error) {
-	return db.Exec(query, args...)
-}
-
 // Getis a type agnostic wrapper for sqlx.Get() (works with sqlx.DB and sqlx.Tx)
 func Get(db Database, obj interface{}, query string, args ...interface{}) (err error) {
 	return db.Get(obj, query, args...)

--- a/utils/test/test.go
+++ b/utils/test/test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/cndy-store/analytics/utils/bigint"
 	"github.com/cndy-store/analytics/utils/cndy"
-	"github.com/cndy-store/analytics/utils/sql"
 	"github.com/jmoiron/sqlx"
 	"time"
 )
@@ -50,7 +49,7 @@ func InsertTestData(tx *sqlx.Tx) (err error) {
 			return
 		}
 
-		_, err = sql.Exec(tx, `INSERT INTO effects(effect_id, operation, paging_token, account, amount, type, asset_type, asset_issuer, asset_code, created_at)
+		_, err = tx.Exec(`INSERT INTO effects(effect_id, operation, paging_token, account, amount, type, asset_type, asset_issuer, asset_code, created_at)
 			                    VALUES($1, 'https://horizon-testnet.stellar.org/operations/34028708058632193', $2, $3, $4, $5, 'credit_alphanum4', $6, $7, $8)`,
 			fmt.Sprintf("0034028708058632193-%09d", i), data.PagingToken, data.Account, amount, data.Type, cndy.AssetIssuer, cndy.AssetCode, data.CreatedAt)
 		if err != nil {
@@ -58,7 +57,7 @@ func InsertTestData(tx *sqlx.Tx) (err error) {
 		}
 	}
 
-	_, err = sql.Exec(tx, `SELECT repopulate_asset_stats()`)
+	_, err = tx.Exec(`SELECT repopulate_asset_stats()`)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In order to support the generic helper functions for transactions and usual
connections, we used to use the generic interface and do manual type-checks
and conversions.

However, as sqlx.DB and sqlx.Tx share the same method signatures, I created a
new interface that contains all used methods and was able to replace the usage
of the generic interface{} with the new one.

This also made the more simple helper functions unnecessary, as they would not only serve as a simple proxy, so I removed them as well.

Overall this change should not have any impact on the behaviour, we just offloaded the typechecking/conversions from the business logic to the compiler.